### PR TITLE
Made forms different for new vs existing modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,7 +164,7 @@ app.route('/module/:x&:y')
   .get(modController.getMod)
   .post(modController.postMod);
 
-app.post('/module/delete/:id', passportConfig.isAuthenticated, modController.postDeleteMod);
+app.delete('/module/delete/:id', passportConfig.isAuthenticated, modController.postDeleteMod);
 app.post('/module/update', passportConfig.isAuthenticated, modController.postUpdateMod);
 /**
  * API examples routes.

--- a/controllers/mod.js
+++ b/controllers/mod.js
@@ -19,18 +19,18 @@ exports.getModMap = (req, res) => {
 };
 
 exports.getMod = (req, res, next) => {
-  x = req.params.x
-  y = req.params.y
+  let x = req.params.x
+  let y = req.params.y
   Plant
     .find()
     .exec((err, plant) => {
       Mod
-        .findOne({ x:x,y:y })
+        .findOne({ x, y })
         .exec((err, module) => {
           if (err) { return next(err); }
           if (!module) {
             req.flash('info', { msg: 'Creating New Module' });
-            return res.render('module', { plants: plant, x:x,y:y });
+            return res.render('module', { exists: false, mod: {model: '', shape: '', orientation: '', notes: ''}, plants: plant, x, y });
           }
           IndividualPlant
             .find({ module: module._id })
@@ -38,11 +38,11 @@ exports.getMod = (req, res, next) => {
               if (err) { return next(err); }
               if (!plantedplants) {
                 req.flash('info', { msg: 'Editing Empty Module' });
-                return res.render('module', { plants: plant, x:x,y:y });
+                return res.render('module', { plants: plant, x, y });
               }
               req.flash('info', { msg: 'Editing Module' });
               console.log(plantedplants);
-              return res.render('module', { plants: plant, x:x, y:y, plantedPlants: plantedplants });
+              return res.render('module', { exists: true, mod: module, plants: plant, x, y, plantedPlants: plantedplants });
             })
         });
     });
@@ -134,7 +134,7 @@ exports.postDeleteMod = (req, res, next) => {
   Mod.deleteOne({ _id: req.params.id }, (err) => {
     if (err) { return next(err); }
     req.flash('info', { msg: 'Module Removed.' });
-    res.redirect('/module');
+    res.redirect('/modmap');
   });
 };
 

--- a/views/module.pug
+++ b/views/module.pug
@@ -2,7 +2,12 @@ extends layout
 
 block content
   .page-header
-    h3 New Module
+    - console.log(mod, exists)
+  #header
+    if exists === true
+      h3 Edit Module
+    else 
+      h3 New Module
     h5#exampleModalLongTitle.modal-title Module Control
     button.close(type='button' onclick='history.back()' aria-label='Close')
       span(aria-hidden='true') &times;
@@ -21,7 +26,8 @@ block content
         .row.col-sm
           .form-group.col-sm
             label(for='model') Model
-            select.form-control(id='model' name='model')
+            select.form-control(id='model' name='model' required)
+              option !{mod.model}
               option 3-d
               option 4-d
               option 5-d
@@ -29,7 +35,8 @@ block content
               option fwm dock 24 footer
           .form-group.col-sm
             label(for='shape') Shape and size
-            select.form-control(id='shape' name='shape')
+            select.form-control(id='shape' name='shape' required)
+              option !{mod.shape}
               option R3
               option R2.3
               option T3
@@ -37,12 +44,13 @@ block content
           .form-group.col-sm
             label(for='orientation') Angled Orientation
             select.form-control(id='orientation' name='orientation')
+              option !{mod.orientation}
               option Flat
               option RH
               option LH
         .form-group
           label(for='notes' ) Notes
-          textarea.form-control(rows='3' id='notes' name='notes')
+          textarea.form-control(rows='3' id='notes' name='notes') !{mod.notes}
         input(type='hidden' name='individualPlants' id='individualPlants' )
         .row
           #circle_1.col-lg-1
@@ -80,3 +88,11 @@ block content
         button.btn.btn-success( type='submit' )
           i.fas.fa-plus.fa-sm
           | Submit
+    form(action='/module/delete/'+ id, method='POST', onsubmit="return confirm('Are you sure you want to delete this module?');")
+      .form-group
+        input(type='hidden', name='_csrf', value=_csrf)
+        button.btn.btn-outline-danger(type='submit')
+          i.fas.fa-trash-alt
+        .pb-2.mt-2.mb-4.border-bottom
+        
+        

--- a/views/modules.pug
+++ b/views/modules.pug
@@ -26,7 +26,7 @@ block content
           button.btn.btn-outline-warning(type='button' name='edit' value=mod._id)
             i.fas.fa-edit.fa-sm
         td
-          form(action='/module/delete/'+ mod.id, method='POST', onsubmit="return confirm('Are you sure you want to delete your account?');")
+          form(action='/module/delete/'+ mod.id, method='POST', onsubmit="return confirm('Are you sure you want to delete this module?');")
             .form-group
               input(type='hidden', name='_csrf', value=_csrf)
               button.btn.btn-outline-danger(type='submit')


### PR DESCRIPTION
Still needs to be linked to create and update pages, but now each x&y page has its own 'mod' variable that contains the module if it already exists, and populates the page with that information, or contains empty strings for the blank form. Minor conditional logic as well to render New Module and Edit Module as the header when the module does not already exist and does respectively. Need to work on linking to backend still, it adds new modules but will add duplicates instead of updating. 