### PR TITLE
Feat/admin filter defaults

### DIFF
--- a/wildmile/app/admin/CameraAdminPage.js
+++ b/wildmile/app/admin/CameraAdminPage.js
@@ -69,23 +69,25 @@ export default function CameraAdminPage() {
     const fetchInitialData = async () => {
       setLoading(true);
       try {
-        // Fetch permissions
-        const permResponse = await fetch("/api/admin/update-user-roles", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            userId: "test",
-            role: "CameraManager",
-            action: "add",
-          }),
-        });
+        // Fetch permissions - Temporarily disabled problematic POST call
+        // TODO: Implement a dedicated GET endpoint to fetch user's manageable permissions
+        // For now, userPermissions will use its initial default value.
+        // const permResponse = await fetch("/api/admin/update-user-roles", {
+        //   method: "POST",
+        //   headers: { "Content-Type": "application/json" },
+        //   body: JSON.stringify({
+        //     userId: "test",
+        //     role: "CameraManager",
+        //     action: "add",
+        //   }),
+        // });
 
-        if (permResponse.ok) {
-          const data = await permResponse.json();
-          if (data.permissions) {
-            setUserPermissions(data.permissions);
-          }
-        }
+        // if (permResponse.ok) {
+        //   const data = await permResponse.json();
+        //   if (data.permissions) {
+        //     setUserPermissions(data.permissions);
+        //   }
+        // }
 
         // Fetch users with roles
         const usersResponse = await fetch(

--- a/wildmile/app/admin/page.js
+++ b/wildmile/app/admin/page.js
@@ -16,6 +16,7 @@ import { getSession } from "lib/getSession";
 import { Suspense } from "react";
 import { cookies, headers } from "next/headers";
 import { AchievementManager } from "components/admin/AchievementManager";
+import { FilterDefaultsAdmin } from "components/admin/FilterDefaultsAdmin";
 
 // In your admin page component
 export const metadata = {
@@ -45,8 +46,11 @@ export default async function Page(props) {
   return (
     <Container>
       <Suspense fallback={<LoadingOverlay visible />}>
-        <Card shadow="sm" p="md" withBorder>
+        <Card shadow="sm" p="md" withBorder mb="lg">
           <CameraAdminPage />
+        </Card>
+        <Card shadow="sm" p="md" withBorder mb="lg">
+          <FilterDefaultsAdmin />
         </Card>
         <Card shadow="sm" p="md" withBorder>
           <AchievementManager />

--- a/wildmile/app/api/admin/filter-defaults/route.js
+++ b/wildmile/app/api/admin/filter-defaults/route.js
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import dbConnect from "lib/db/setup";
+import FilterDefault from "models/FilterDefault";
+import { getSession } from "lib/getSession"; // For authentication
+import { headers } from "next/headers"; // To pass to getSession
+
+const DEFAULT_FILTER_NAME = "cameratrapIdentifyDefaults";
+
+// Helper function to check for admin privileges
+async function isAdmin(session) {
+  if (
+    !session ||
+    (!session.admin &&
+      !session.roles.includes("SuperAdmin") &&
+      !session.roles.includes("Admin") &&
+      !session.roles.includes("CameraAdmin"))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export async function GET(request) {
+  await dbConnect();
+  try {
+    let defaults = await FilterDefault.findOne({ name: DEFAULT_FILTER_NAME });
+
+    if (!defaults) {
+      // If no defaults are found, we can either create a new one with schema defaults
+      // or return the schema's default values directly.
+      // For now, let's create one so it exists in the DB for future POSTs.
+      // Or, more simply, just return what the frontend expects as a default structure.
+      // The model itself has defaults, so instantiating one without saving gives us those.
+      const modelDefaults = new FilterDefault().toObject();
+      // Remove _id and other mongoose specific fields if not needed by frontend for a "non-existent" entry
+      delete modelDefaults._id;
+      delete modelDefaults.createdAt;
+      delete modelDefaults.updatedAt;
+      delete modelDefaults.__v;
+
+
+      return NextResponse.json(modelDefaults, { status: 200 });
+    }
+
+    return NextResponse.json(defaults, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching filter defaults:", error);
+    return NextResponse.json(
+      { message: "Error fetching filter defaults", error: error.message },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request) {
+  const session = await getSession({ headers });
+  if (!(await isAdmin(session))) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  await dbConnect();
+  try {
+    const body = await request.json();
+
+    // Ensure the name is always the one we use for these defaults
+    body.name = DEFAULT_FILTER_NAME;
+
+    // Validate animalProbability (example, more validation can be added)
+    if (body.animalProbability) {
+      if (!Array.isArray(body.animalProbability) || body.animalProbability.length !== 2) {
+        return NextResponse.json({ message: "animalProbability must be an array of two numbers." }, { status: 400 });
+      }
+      if (typeof body.animalProbability[0] !== 'number' || typeof body.animalProbability[1] !== 'number') {
+        return NextResponse.json({ message: "animalProbability values must be numbers." }, { status: 400 });
+      }
+      if (body.animalProbability[0] > body.animalProbability[1]) {
+        return NextResponse.json({ message: "Min animalProbability cannot exceed Max animalProbability." }, { status: 400 });
+      }
+    }
+
+    // Sanitize or validate other fields as necessary
+    // For example, ensure dates are valid, locationId format is correct, etc.
+
+    const updatedDefaults = await FilterDefault.findOneAndUpdate(
+      { name: DEFAULT_FILTER_NAME },
+      body,
+      { new: true, upsert: true, runValidators: true }
+    );
+
+    return NextResponse.json(updatedDefaults, { status: 200 });
+  } catch (error) {
+    console.error("Error updating filter defaults:", error);
+    // Handle validation errors specifically if needed
+    if (error.name === 'ValidationError') {
+      return NextResponse.json({ message: "Validation Error", errors: error.errors }, { status: 400 });
+    }
+    return NextResponse.json(
+      { message: "Error updating filter defaults", error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/wildmile/components/admin/AchievementManager.js
+++ b/wildmile/components/admin/AchievementManager.js
@@ -428,7 +428,7 @@ export function AchievementManager() {
                 <Table.Td>
                   <Group>
                     <Image
-                      src={achievement.badge}
+                      src={achievement.badge || null} // Ensure null if empty string
                       alt={achievement.name}
                       width={40}
                       height={40}

--- a/wildmile/components/admin/FilterDefaultsAdmin.js
+++ b/wildmile/components/admin/FilterDefaultsAdmin.js
@@ -8,14 +8,15 @@ import {
   Title,
   Text,
   Select,
-  DateInput,
-  TimeInput,
+  // DateInput, // Will be imported from @mantine/dates
+  // TimeInput, // Will be imported from @mantine/dates
   Switch,
   NumberInput,
   LoadingOverlay,
   Alert,
   ActionIcon,
 } from "@mantine/core";
+import { DateInput, TimeInput } from "@mantine/dates"; // Correct import
 import { IconX, IconAlertCircle, IconCheck } from "@tabler/icons-react";
 
 const initialFormState = {

--- a/wildmile/components/admin/FilterDefaultsAdmin.js
+++ b/wildmile/components/admin/FilterDefaultsAdmin.js
@@ -208,7 +208,7 @@ export function FilterDefaultsAdmin() {
           data={locations}
           value={formState.locationId}
           onChange={(value) => handleInputChange("locationId", value)}
-          clearable
+          clearable={true}
           rightSection={
             formState.locationId && (
               <ActionIcon onClick={() => handleClearInput("locationId")} size="sm" variant="transparent">
@@ -223,14 +223,14 @@ export function FilterDefaultsAdmin() {
             placeholder="No default start date"
             value={formState.startDate}
             onChange={(value) => handleInputChange("startDate", value)}
-            clearable
+            clearable={true}
           />
           <DateInput
             label="Default End Date"
             placeholder="No default end date"
             value={formState.endDate}
             onChange={(value) => handleInputChange("endDate", value)}
-            clearable
+            clearable={true}
           />
         </Group>
         <Group grow>
@@ -240,7 +240,7 @@ export function FilterDefaultsAdmin() {
             value={formState.startTime}
             onChange={(value) => handleTimeChange("startTime", value)}
             onBlur={(e) => handleTimeChange("startTime", e.currentTarget.value)}
-            clearable
+            clearable={true}
             rightSection={
                 formState.startTime && (
                   <ActionIcon onClick={() => handleClearInput("startTime")} size="sm" variant="transparent">
@@ -255,7 +255,7 @@ export function FilterDefaultsAdmin() {
             value={formState.endTime}
             onChange={(value) => handleTimeChange("endTime", value)}
             onBlur={(e) => handleTimeChange("endTime", e.currentTarget.value)}
-            clearable
+            clearable={true}
             rightSection={
                 formState.endTime && (
                   <ActionIcon onClick={() => handleClearInput("endTime")} size="sm" variant="transparent">

--- a/wildmile/components/admin/FilterDefaultsAdmin.js
+++ b/wildmile/components/admin/FilterDefaultsAdmin.js
@@ -1,0 +1,320 @@
+"use client";
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  Button,
+  Group,
+  Stack,
+  Paper,
+  Title,
+  Text,
+  Select,
+  DateInput,
+  TimeInput,
+  Switch,
+  NumberInput,
+  LoadingOverlay,
+  Alert,
+  ActionIcon,
+} from "@mantine/core";
+import { IconX, IconAlertCircle, IconCheck } from "@tabler/icons-react";
+
+const initialFormState = {
+  locationId: null,
+  startDate: null,
+  endDate: null,
+  startTime: "",
+  endTime: "",
+  reviewed: false,
+  reviewedByUser: false,
+  animalProbability: [0.75, 1.0], // Default as per ImageFilterControls
+};
+
+export function FilterDefaultsAdmin() {
+  const [formState, setFormState] = useState(initialFormState);
+  const [locations, setLocations] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(null);
+
+  const fetchLocations = useCallback(async () => {
+    try {
+      const response = await fetch(
+        "/api/cameratrap/getDeploymentLocations?onlyUsed=true"
+      );
+      if (response.ok) {
+        const data = await response.json();
+        setLocations(
+          data.map((l) => ({ value: l._id, label: l.locationName }))
+        );
+      } else {
+        console.error("Failed to fetch locations");
+        setError("Failed to fetch locations for dropdown.");
+      }
+    } catch (err) {
+      console.error("Error fetching locations:", err);
+      setError("Error fetching locations: " + err.message);
+    }
+  }, []);
+
+  const fetchDefaults = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/admin/filter-defaults");
+      if (response.ok) {
+        const data = await response.json();
+        // Ensure dates are Date objects if they are string representations
+        const processedData = {
+          ...data,
+          startDate: data.startDate ? new Date(data.startDate) : null,
+          endDate: data.endDate ? new Date(data.endDate) : null,
+          animalProbability: Array.isArray(data.animalProbability) && data.animalProbability.length === 2
+                             ? data.animalProbability
+                             : initialFormState.animalProbability, // Fallback if data is malformed
+        };
+        setFormState(processedData);
+      } else {
+        const errData = await response.json();
+        setError(errData.message || "Failed to fetch filter defaults.");
+      }
+    } catch (err) {
+      console.error("Error fetching filter defaults:", err);
+      setError("Error fetching filter defaults: " + err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLocations();
+    fetchDefaults();
+  }, [fetchLocations, fetchDefaults]);
+
+  const handleInputChange = (key, value) => {
+    setFormState((prev) => ({ ...prev, [key]: value }));
+    setError(null);
+    setSuccess(null);
+  };
+
+  const handleTimeChange = (key, value) => {
+    // Basic HH:MM validation or allow empty string
+    if (!value || /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/.test(value)) {
+       handleInputChange(key, value);
+    }
+  };
+
+  const handleClearInput = (key) => {
+    const defaultValue = initialFormState[key]; // Or actual schema defaults if preferred for "clear"
+    if (key === 'animalProbability') {
+        setFormState((prev) => ({ ...prev, [key]: [0,1] })); // Resetting to full range
+    } else if (typeof defaultValue === 'boolean') {
+        setFormState((prev) => ({ ...prev, [key]: false }));
+    } else if (key === 'startTime' || key === 'endTime') {
+        setFormState((prev) => ({ ...prev, [key]: "" }));
+    }
+     else {
+        setFormState((prev) => ({ ...prev, [key]: null }));
+    }
+    setError(null);
+    setSuccess(null);
+  };
+
+
+  const handleSubmit = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const payload = {
+        ...formState,
+        // Ensure dates are sent in ISO format or whatever backend expects if not already
+        startDate: formState.startDate ? formState.startDate.toISOString() : null,
+        endDate: formState.endDate ? formState.endDate.toISOString() : null,
+      };
+      const response = await fetch("/api/admin/filter-defaults", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        // Update form state with potentially processed data from backend (e.g. timestamps)
+         const processedData = {
+          ...data,
+          startDate: data.startDate ? new Date(data.startDate) : null,
+          endDate: data.endDate ? new Date(data.endDate) : null,
+        };
+        setFormState(processedData);
+        setSuccess("Filter defaults saved successfully!");
+      } else {
+        const errData = await response.json();
+        setError(errData.message || "Failed to save filter defaults.");
+        if (errData.errors) {
+            // Handle specific validation errors if needed
+            console.error("Validation errors:", errData.errors)
+        }
+      }
+    } catch (err) {
+      console.error("Error saving filter defaults:", err);
+      setError("Error saving filter defaults: " + err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Paper shadow="sm" p="md" withBorder>
+      <LoadingOverlay visible={loading && !saving} />
+      <Title order={3} mb="md">
+        Camera Trap Filter Defaults
+      </Title>
+      <Text size="sm" color="dimmed" mb="lg">
+        Set the default filter values for the camera trap identify page. These
+        will be applied when a user first visits the page or clears their
+        filters.
+      </Text>
+
+      {error && (
+        <Alert
+          icon={<IconAlertCircle size="1rem" />}
+          title="Error"
+          color="red"
+          withCloseButton
+          onClose={() => setError(null)}
+          mb="md"
+        >
+          {error}
+        </Alert>
+      )}
+      {success && (
+        <Alert
+          icon={<IconCheck size="1rem" />}
+          title="Success"
+          color="green"
+          withCloseButton
+          onClose={() => setSuccess(null)}
+          mb="md"
+        >
+          {success}
+        </Alert>
+      )}
+
+      <Stack spacing="md">
+        <Select
+          label="Default Location"
+          placeholder="Select a default location or leave empty"
+          data={locations}
+          value={formState.locationId}
+          onChange={(value) => handleInputChange("locationId", value)}
+          clearable
+          rightSection={
+            formState.locationId && (
+              <ActionIcon onClick={() => handleClearInput("locationId")} size="sm" variant="transparent">
+                <IconX size={14} />
+              </ActionIcon>
+            )
+          }
+        />
+        <Group grow>
+          <DateInput
+            label="Default Start Date"
+            placeholder="No default start date"
+            value={formState.startDate}
+            onChange={(value) => handleInputChange("startDate", value)}
+            clearable
+          />
+          <DateInput
+            label="Default End Date"
+            placeholder="No default end date"
+            value={formState.endDate}
+            onChange={(value) => handleInputChange("endDate", value)}
+            clearable
+          />
+        </Group>
+        <Group grow>
+          <TimeInput
+            label="Default Start Time"
+            placeholder="e.g., 09:00"
+            value={formState.startTime}
+            onChange={(value) => handleTimeChange("startTime", value)}
+            onBlur={(e) => handleTimeChange("startTime", e.currentTarget.value)}
+            clearable
+            rightSection={
+                formState.startTime && (
+                  <ActionIcon onClick={() => handleClearInput("startTime")} size="sm" variant="transparent">
+                    <IconX size={14} />
+                  </ActionIcon>
+                )
+            }
+          />
+          <TimeInput
+            label="Default End Time"
+            placeholder="e.g., 17:00"
+            value={formState.endTime}
+            onChange={(value) => handleTimeChange("endTime", value)}
+            onBlur={(e) => handleTimeChange("endTime", e.currentTarget.value)}
+            clearable
+            rightSection={
+                formState.endTime && (
+                  <ActionIcon onClick={() => handleClearInput("endTime")} size="sm" variant="transparent">
+                    <IconX size={14} />
+                  </ActionIcon>
+                )
+            }
+          />
+        </Group>
+        <Switch
+          label="Default to 'Reviewed Images Only'"
+          checked={formState.reviewed}
+          onChange={(event) =>
+            handleInputChange("reviewed", event.currentTarget.checked)
+          }
+        />
+        <Switch
+          label="Default to 'Images Reviewed by Me Only'"
+          checked={formState.reviewedByUser}
+          onChange={(event) =>
+            handleInputChange("reviewedByUser", event.currentTarget.checked)
+          }
+        />
+        <Group grow align="flex-start" mt="xs">
+            <NumberInput
+              label="Default Min Animal %"
+              placeholder="0-100"
+              value={Math.round(formState.animalProbability[0] * 100)}
+              onChange={(value) => {
+                const newMinDecimal = Math.max(0, Math.min(100, Number(value) || 0)) / 100;
+                const currentMaxDecimal = formState.animalProbability[1];
+                const newProb = newMinDecimal <= currentMaxDecimal ? [newMinDecimal, currentMaxDecimal] : [currentMaxDecimal, currentMaxDecimal];
+                handleInputChange("animalProbability", newProb);
+              }}
+              min={0}
+              max={100}
+              step={1}
+            />
+            <NumberInput
+              label="Default Max Animal %"
+              placeholder="0-100"
+              value={Math.round(formState.animalProbability[1] * 100)}
+              onChange={(value) => {
+                const newMaxDecimal = Math.max(0, Math.min(100, Number(value) || 0)) / 100;
+                const currentMinDecimal = formState.animalProbability[0];
+                const newProb = newMaxDecimal >= currentMinDecimal ? [currentMinDecimal, newMaxDecimal] : [currentMinDecimal, currentMinDecimal];
+                handleInputChange("animalProbability", newProb);
+              }}
+              min={0}
+              max={100}
+              step={1}
+            />
+          </Group>
+
+        <Button onClick={handleSubmit} loading={saving} mt="md">
+          Save Defaults
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}
+
+export default FilterDefaultsAdmin;

--- a/wildmile/components/admin/FilterDefaultsAdmin.js
+++ b/wildmile/components/admin/FilterDefaultsAdmin.js
@@ -208,7 +208,7 @@ export function FilterDefaultsAdmin() {
           data={locations}
           value={formState.locationId}
           onChange={(value) => handleInputChange("locationId", value)}
-          clearable={true}
+          // clearable={true} // Removed to prevent warning
           rightSection={
             formState.locationId && (
               <ActionIcon onClick={() => handleClearInput("locationId")} size="sm" variant="transparent">
@@ -223,14 +223,14 @@ export function FilterDefaultsAdmin() {
             placeholder="No default start date"
             value={formState.startDate}
             onChange={(value) => handleInputChange("startDate", value)}
-            clearable={true}
+            // clearable={true} // Removed to prevent warning
           />
           <DateInput
             label="Default End Date"
             placeholder="No default end date"
             value={formState.endDate}
             onChange={(value) => handleInputChange("endDate", value)}
-            clearable={true}
+            // clearable={true} // Removed to prevent warning
           />
         </Group>
         <Group grow>
@@ -240,7 +240,7 @@ export function FilterDefaultsAdmin() {
             value={formState.startTime}
             onChange={(value) => handleTimeChange("startTime", value)}
             onBlur={(e) => handleTimeChange("startTime", e.currentTarget.value)}
-            clearable={true}
+            // clearable={true} // Removed to prevent warning
             rightSection={
                 formState.startTime && (
                   <ActionIcon onClick={() => handleClearInput("startTime")} size="sm" variant="transparent">
@@ -255,7 +255,7 @@ export function FilterDefaultsAdmin() {
             value={formState.endTime}
             onChange={(value) => handleTimeChange("endTime", value)}
             onBlur={(e) => handleTimeChange("endTime", e.currentTarget.value)}
-            clearable={true}
+            // clearable={true} // Removed to prevent warning
             rightSection={
                 formState.endTime && (
                   <ActionIcon onClick={() => handleClearInput("endTime")} size="sm" variant="transparent">

--- a/wildmile/models/FilterDefault.js
+++ b/wildmile/models/FilterDefault.js
@@ -1,0 +1,53 @@
+import mongoose from "mongoose";
+
+const FilterDefaultSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      unique: true,
+      default: "cameratrapIdentifyDefaults", // Identifier for this specific set of defaults
+    },
+    locationId: {
+      type: String, // Or mongoose.Schema.Types.ObjectId if it references another model directly
+      default: null,
+    },
+    startDate: {
+      type: Date,
+      default: null,
+    },
+    endDate: {
+      type: Date,
+      default: null,
+    },
+    startTime: {
+      type: String, // Storing as string e.g., "HH:MM"
+      default: "",
+    },
+    endTime: {
+      type: String, // Storing as string e.g., "HH:MM"
+      default: "",
+    },
+    reviewed: {
+      type: Boolean,
+      default: false,
+    },
+    reviewedByUser: {
+      type: Boolean,
+      default: false,
+    },
+    animalProbability: {
+      type: [Number], // Should be an array of two numbers [min, max]
+      default: [0.75, 1.0],
+      validate: [
+        (val) => val.length === 2 && val[0] <= val[1],
+        "Animal probability must be an array of two numbers [min, max] where min <= max.",
+      ],
+    },
+    // Add any other filters that might become defaultable in the future
+  },
+  { timestamps: true }
+);
+
+export default mongoose.models.FilterDefault ||
+  mongoose.model("FilterDefault", FilterDefaultSchema);


### PR DESCRIPTION
Adds admin filter default settings to admin page - requires admin=True and roles "Admin, CameraAdmin, or SuperAdmin"

Hardcoded defaults exists as a baseline/safety net in code

Admin set defaults are stored in the mongodb - take precedence for all users when loading the identify page. User filter settings stay on until the page is reloaded.

Closes Issue #274 

### Files Changed
/wildmile/app/admin/CameraAdminPage.js  
- Disabled problematic POST request for the test user ID

/wildmile/app/admin/page.js
- Adds FilterDefaultsAdmin component to admin page

/wildmile/app/api/admin/filter-defaults/route.js
- Major content addition
- Handles post requests validation so 'saving' defaults to the mongoDB filterdefaults collection is checked or left at the defaults

/wildmile/components/admin/AchievementManager.js
- Fixes bug if no badges exists, filling with Null if needed

/wildmile/components/admin/FilterDefaultsAdmin.js
- Major content addition
- Configures the filter defaults card
- handleSubmit passes the post request with validation from filter-defaults/route.js

/wildmile/components/cameratrap/ImageAnnotationPage.js
- Modifies identify image annotation page to load filter defaults from get request

/wildmile/components/cameratrap/ImageFilterControls.js
- Changes clear all filters functionality to allow for truly blank filters
- Modifies behavior of identify page filter tools to interact with defaults and take precedence for the user if the user makes a modification

/wildmile/models/FilterDefault.js
- Major content addition
- Defines the filterdefaults collection model for mongoDB/mongoose schema