### PR TITLE
patch - save all emails as lowercase

### DIFF
--- a/wildmile/lib/db/user.js
+++ b/wildmile/lib/db/user.js
@@ -32,7 +32,7 @@ export async function createUser({
   await dbConnect()
   // Here you should insert the user into the database
   const user = await User.create({
-    email: email,
+    email: email.toLowerCase(),
     password: password,
     profile: {
       name: name,
@@ -80,10 +80,10 @@ export async function findUserByEmail(email) {
 export async function updateUserByEmail(req, email, update) {
   await dbConnect()
   // Updating requires the _id which we filter out of results in other places so lets
-  const user = await User.findOne({ email: email });
+  const user = await User.findOne({ email: email.toLowerCase() });
 
-  if (update.email && update.email != user.email) {
-    user.email = update.email;
+  if (update.email && update.email.toLowerCase() != user.email) {
+    user.email = update.email.toLowerCase();
   }
   if (update.password && !(await user.comparePassword(password))) {
     user.password = update.password;


### PR DESCRIPTION
Issue:
If a user registered as User@Example.com (stored with uppercase) and tries to log in as user@example.com (which gets converted to lowercase by findUserByEmail), the database query User.findOne({ email: 'user@example.com' }) would not match User@Example.com

Also applies change to update email function.

Fixes inconsistency between line 72 - where finding users emails checks for lowercase email

This fixes new registrations, but doesn't fix old registrations (these users will continue to have issues while their credentials are stored with some capitalization)
For a full resolution we will also need to run a script that updates all existing emails in the db to lower case