### PR TITLE
Fix achievement ranking logic 5934874079735765904

### DIFF
--- a/wildmile/models/users/UserProgress.js
+++ b/wildmile/models/users/UserProgress.js
@@ -88,8 +88,10 @@ UserProgressSchema.methods.checkAchievements = async function () {
   // First validate existing achievements
   await this.validateAchievements();
 
-  // Get all active achievements
-  const achievements = await Achievement.find({ isActive: true });
+  // Get all active achievements and sort by level to ensure correct rank progression
+  const achievements = await Achievement.find({ isActive: true }).sort({
+    level: 1,
+  });
   console.log(`Found ${achievements.length} active achievements`);
 
   // Remove any unearned achievements to prevent duplicates
@@ -170,6 +172,14 @@ UserProgressSchema.methods.checkAchievements = async function () {
           domainPoints[achievement.domain] =
             (domainPoints[achievement.domain] || 0) + achievement.points;
         }
+
+        // Update domain rank if eligible (even if previously earned)
+        // Since achievements are sorted by level, the highest eligible rank will be set last
+        if (eligible) {
+          const domainRank = this.domainRanks.get(achievement.domain) || {};
+          domainRank.currentRank = achievement._id;
+          this.domainRanks.set(achievement.domain, domainRank);
+        }
       } else {
         // Add new achievement
         console.log(`Adding new achievement: ${achievement.name}`);
@@ -249,12 +259,15 @@ UserProgressSchema.methods.checkAchievements = async function () {
           domainPoints[achievement.domain] =
             (domainPoints[achievement.domain] || 0) + achievement.points;
 
-          // Update domain rank
+          newAchievements.push(achievement);
+        }
+
+        // Always update domain rank if eligible (even if previously earned)
+        // Since achievements are sorted by level, the highest eligible rank will be set last
+        if (eligible) {
           const domainRank = this.domainRanks.get(achievement.domain) || {};
           domainRank.currentRank = achievement._id;
           this.domainRanks.set(achievement.domain, domainRank);
-
-          newAchievements.push(achievement);
         }
       }
     } catch (error) {


### PR DESCRIPTION
Jules fixed a bug in the achievement system where users would get stuck at certain ranks (like 'Busy Beaver') even after meeting higher criteria. The issue was twofold: ranks were being processed in an arbitrary order, and the 'currentRank' was only updated when a rank was first added to a user's profile. I've updated the logic to sort ranks by level and ensure the highest eligible rank is always set as the user's current status.