### PR TITLE
Add video playback to explore page

### DIFF
--- a/wildmile/components/cameratrap/ImageAnnotation.js
+++ b/wildmile/components/cameratrap/ImageAnnotation.js
@@ -399,16 +399,17 @@ export function ImageAnnotation({ fetchNextImage, filters }) {
                   <IconFocus2 />
                 </ActionIcon>
               </Tooltip>
-              <Tooltip label="Play Video">
-                <ActionIcon
-                  onClick={() => setShowVideo(true)}
-                  variant="outline"
-                  color="teal"
-                  disabled={!currentImage?.videoUrl}
-                >
-                  <IconPlayerPlay />
-                </ActionIcon>
-              </Tooltip>
+              {currentImage?.videoUrl && (
+                <Tooltip label="Play Video">
+                  <ActionIcon
+                    onClick={() => setShowVideo(true)}
+                    variant="outline"
+                    color="teal"
+                  >
+                    <IconPlayerPlay />
+                  </ActionIcon>
+                </Tooltip>
+              )}
               <Tooltip label="Need Help with ID">
                 <ActionIcon
                   onClick={handleNeedsReview}

--- a/wildmile/components/cameratrap/ImageAnnotation.js
+++ b/wildmile/components/cameratrap/ImageAnnotation.js
@@ -399,17 +399,16 @@ export function ImageAnnotation({ fetchNextImage, filters }) {
                   <IconFocus2 />
                 </ActionIcon>
               </Tooltip>
-              {currentImage?.videoUrl && (
-                <Tooltip label="Play Video">
-                  <ActionIcon
-                    onClick={() => setShowVideo(true)}
-                    variant="outline"
-                    color="teal"
-                  >
-                    <IconPlayerPlay />
-                  </ActionIcon>
-                </Tooltip>
-              )}
+              <Tooltip label="Play Video">
+                <ActionIcon
+                  onClick={() => setShowVideo(true)}
+                  variant="outline"
+                  color="teal"
+                  disabled={!currentImage?.videoUrl}
+                >
+                  <IconPlayerPlay />
+                </ActionIcon>
+              </Tooltip>
               <Tooltip label="Need Help with ID">
                 <ActionIcon
                   onClick={handleNeedsReview}

--- a/wildmile/components/cameratrap/images/ImageGallery.js
+++ b/wildmile/components/cameratrap/images/ImageGallery.js
@@ -196,17 +196,18 @@ function ImageInfo({ image, onVideoClick }) {
           })}
         </Text>
         <Group gap={4} wrap="nowrap">
-          <Tooltip label="Play Video">
-            <ActionIcon
-              onClick={onVideoClick}
-              variant="subtle"
-              size="xs"
-              color="teal"
-              disabled={!image?.videoUrl}
-            >
-              <IconPlayerPlay size={14} />
-            </ActionIcon>
-          </Tooltip>
+          {image?.videoUrl && (
+            <Tooltip label="Play Video">
+              <ActionIcon
+                onClick={onVideoClick}
+                variant="subtle"
+                size="xs"
+                color="teal"
+              >
+                <IconPlayerPlay size={14} />
+              </ActionIcon>
+            </Tooltip>
+          )}
           <Tooltip label="Go to image">
             <ActionIcon
               component={Link}

--- a/wildmile/components/cameratrap/images/ImageGallery.js
+++ b/wildmile/components/cameratrap/images/ImageGallery.js
@@ -14,7 +14,12 @@ import {
   Box,
   NumberInput,
 } from "@mantine/core";
-import { IconEye, IconHeart, IconLink } from "@tabler/icons-react";
+import {
+  IconEye,
+  IconHeart,
+  IconLink,
+  IconPlayerPlay,
+} from "@tabler/icons-react";
 import Link from "next/link";
 
 import { SpeciesConsensusBadges } from "../SpeciesConsensusBadges";
@@ -90,6 +95,7 @@ export function ImageGallery({
 
 export function ImageCard({ image, imageHeight }) {
   const [opened, setOpened] = useState(false);
+  const [videoOpened, setVideoOpened] = useState(false);
 
   return (
     <Paper p="xs" withBorder>
@@ -104,7 +110,7 @@ export function ImageCard({ image, imageHeight }) {
           style={{ cursor: "pointer" }}
           onClick={() => setOpened(true)}
         />
-        <ImageInfo image={image} />
+        <ImageInfo image={image} onVideoClick={() => setVideoOpened(true)} />
 
         <Modal
           opened={opened}
@@ -135,15 +141,32 @@ export function ImageCard({ image, imageHeight }) {
               Location:{" "}
               {image.deploymentId?.locationId?.locationName || "Unknown"}
             </Text>
-            <ImageInfo image={image} />
+            <ImageInfo image={image} onVideoClick={() => setVideoOpened(true)} />
           </Group>
+        </Modal>
+        <Modal
+          opened={videoOpened}
+          onClose={() => setVideoOpened(false)}
+          title="Attached Video"
+          size="lg"
+        >
+          {image?.videoUrl && (
+            <video
+              src={image.videoUrl}
+              controls
+              autoPlay
+              style={{ width: "100%", maxHeight: "80vh" }}
+            >
+              Your browser does not support the video tag.
+            </video>
+          )}
         </Modal>
       </Stack>
     </Paper>
   );
 }
 
-function ImageInfo({ image }) {
+function ImageInfo({ image, onVideoClick }) {
   return (
     <Stack justify="flex-start" gap={1}>
       <Group position="apart" wrap="nowrap">
@@ -172,17 +195,30 @@ function ImageInfo({ image }) {
             minute: "2-digit",
           })}
         </Text>
-        <Tooltip label="Go to image">
-          <ActionIcon
-            component={Link}
-            href={`/cameratrap/identify/${image.mediaID}`}
-            variant="subtle"
-            size="xs"
-            justify="flex-end"
-          >
-            <IconLink size={14} />
-          </ActionIcon>
-        </Tooltip>
+        <Group gap={4} wrap="nowrap">
+          <Tooltip label="Play Video">
+            <ActionIcon
+              onClick={onVideoClick}
+              variant="subtle"
+              size="xs"
+              color="teal"
+              disabled={!image?.videoUrl}
+            >
+              <IconPlayerPlay size={14} />
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="Go to image">
+            <ActionIcon
+              component={Link}
+              href={`/cameratrap/identify/${image.mediaID}`}
+              variant="subtle"
+              size="xs"
+              justify="flex-end"
+            >
+              <IconLink size={14} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
       </Group>
     </Stack>
   );


### PR DESCRIPTION
New button shows on explore (imagegallery) page if there's an available video. 
Button is hidden if no videoUrl exists.

Button appears on annotation page but greyed out if no video (as before)