### PR TITLE
Feature/flexible observation pane

### DIFF
--- a/wildmile/components/cameratrap/ImageAnnotationPage.js
+++ b/wildmile/components/cameratrap/ImageAnnotationPage.js
@@ -231,7 +231,13 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
           </div>
         </GridCol>
 
-        <GridCol span={{ base: 12, md: 3, lg: 3 }} style={{ height: "calc(100vh - 100px)" }}>
+        <GridCol 
+        span={{ base: 12, md: 3, lg: 3 }} 
+        style={{
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+          }}>
           <ObservationTally fetchNextImage={fetchNextImage} />
         </GridCol>
 


### PR DESCRIPTION
simple fix - makes observation pane fit the selected species

This keeps the submit observation buttons in the same place as long as the selected species are the same - this way when people are labeling bursts of images or blanks the button stays in one place - if changing the species selection, the button moves (but that's ok since you're already making selections)

Confirmed tutorial still works
<img width="1331" height="547" alt="image" src="https://github.com/user-attachments/assets/cbaa2049-7c23-42c7-99a3-32fb705afe27" />

with narrower screens this collapses the observation pane white space.
<img width="477" height="623" alt="image" src="https://github.com/user-attachments/assets/09966b43-01f8-40a7-ac83-8a2c6f17e624" />
