### PR TITLE
Auto-start camera trap tutorial for first-time annotators

### DIFF
--- a/wildmile/components/cameratrap/ImageAnnotationPage.js
+++ b/wildmile/components/cameratrap/ImageAnnotationPage.js
@@ -94,6 +94,20 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
     // Adding initialImageId and fetchFilterDefaults to dependencies.
   }, [initialImageId, fetchFilterDefaults]); // Removed fetchDeployments from here as it's stable and not in useCallback
 
+  // Auto-start tutorial for first-time annotators. A successful save sets the
+  // "wildmile.hasAnnotated" flag in localStorage (see ObservationTally), so the
+  // tutorial only fires until the user completes one observation.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (!window.localStorage.getItem("wildmile.hasAnnotated")) {
+        setRunTutorial((prev) => prev + 1);
+      }
+    } catch (e) {
+      // localStorage may be unavailable (private mode); fail silently.
+    }
+  }, [setRunTutorial]);
+
   const fetchDeployments = async () => {
     try {
       const response = await fetch("/api/cameratrap/getDeployments");
@@ -188,11 +202,12 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
         gutter="md"
       >
         <GridCol
-          span={{ base: 12, md: 5, lg: 5 }}
+          span={{ base: 12, md: 8, lg: 8 }}
           style={{
             height: "100%",
             display: "flex",
             flexDirection: "column",
+            minHeight: 0,
           }}
         >
           <Group id="main-navigation-bar" gap="xs" justify="center" mb="xs">
@@ -226,13 +241,12 @@ export const ImageAnnotationPage = ({ initialImageId }) => {
               deployments={deployments}
             />
           </Group>
-          <div style={{ flex: 1, minHeight: 0 }}>
-            <ImageAnnotation filters={appliedFilters} />
+          <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", gap: "var(--mantine-spacing-md)" }}>
+            <div style={{ flex: 1, minHeight: 0 }}>
+              <ImageAnnotation filters={appliedFilters} />
+            </div>
+            <ObservationTally fetchNextImage={fetchNextImage} />
           </div>
-        </GridCol>
-
-        <GridCol span={{ base: 12, md: 3, lg: 3 }} style={{ height: "calc(100vh - 100px)" }}>
-          <ObservationTally fetchNextImage={fetchNextImage} />
         </GridCol>
 
         <GridCol span={{ base: 12, md: 4, lg: 4 }} style={{ height: "calc(100vh - 100px)" }}>

--- a/wildmile/components/cameratrap/ObservationTally.js
+++ b/wildmile/components/cameratrap/ObservationTally.js
@@ -10,7 +10,6 @@ import {
   Checkbox,
   TextInput,
   ActionIcon,
-  ScrollArea,
   Flex,
   Paper,
 } from "@mantine/core";
@@ -185,6 +184,12 @@ export function ObservationTally({ fetchNextImage }) {
 
       if (response.ok) {
         const data = await response.json();
+        try {
+          // First successful save dismisses the auto-tutorial on future visits.
+          window.localStorage.setItem("wildmile.hasAnnotated", "true");
+        } catch (e) {
+          // localStorage may be unavailable; fail silently.
+        }
         if (data.savedSpecies?.length) {
           setRecentSpecies((prev) => {
             const existingNames = new Set(
@@ -268,10 +273,10 @@ export function ObservationTally({ fetchNextImage }) {
       p="md"
       withBorder
       radius="md"
-      h="100%"
       id="observation-tally-container"
+      style={{ display: "flex", flexDirection: "column", flexShrink: 0 }}
     >
-      <Stack gap="md" h="100%">
+      <Stack gap="md">
         <Group justify="space-between" align="center">
           <Text fw={700}>Observations</Text>
           <Button
@@ -286,11 +291,10 @@ export function ObservationTally({ fetchNextImage }) {
           </Button>
         </Group>
 
-        <ScrollArea style={{ flex: 1 }} offsetScrollbars>
-          <Stack gap="md">
-            {!noAnimalsVisible && selection.length > 0 && (
-              <Flex direction="column" gap="xs">
-                {selection.map((animal, index) => {
+        <Stack gap="md">
+          {!noAnimalsVisible && selection.length > 0 && (
+            <Flex direction="row" wrap="wrap" gap="xs">
+              {selection.map((animal, index) => {
                   const animalId = animal.taxonId || animal.id;
                   const bgColor =
                     SELECTION_COLORS[index % SELECTION_COLORS.length];
@@ -372,22 +376,21 @@ export function ObservationTally({ fetchNextImage }) {
               </Flex>
             )}
 
-            {comments.length > 0 && (
-              <Stack gap="xs">
-                <Text size="sm" fw={700}>
-                  Recent Comments
+          {comments.length > 0 && (
+            <Stack gap="xs">
+              <Text size="sm" fw={700}>
+                Recent Comments
+              </Text>
+              {comments.map((comment, index) => (
+                <Text key={index} size="sm">
+                  <strong>{comment.author.name}:</strong> {comment.text}
                 </Text>
-                {comments.map((comment, index) => (
-                  <Text key={index} size="sm">
-                    <strong>{comment.author.name}:</strong> {comment.text}
-                  </Text>
-                ))}
-              </Stack>
-            )}
-          </Stack>
-        </ScrollArea>
+              ))}
+            </Stack>
+          )}
+        </Stack>
 
-        <Stack gap="md" mt="auto">
+        <Stack gap="md">
           <Group grow wrap="nowrap" id="human-vehicle-checkboxes">
             <Checkbox
               classNames={checkboxClasses}


### PR DESCRIPTION
## Summary
- Auto-activates the Joyride tutorial on the camera trap annotation page when a user has never saved an observation. A `wildmile.hasAnnotated` flag is written to `localStorage` on the first successful save, so the tutorial only fires until the user completes one observation; afterwards it's only reachable via the existing **Help** button.
- Restructures the annotation layout so the `ObservationTally` renders **underneath** the image inside the same flex column instead of in a separate sidebar. The wildlife search keeps its own column.
- Turns the selected-animals list into a wrapping flex row so observation chips flow horizontally under the wider image area instead of stacking vertically.

## Why
Previously the tutorial only opened when a user clicked **Help**, so first-time annotators had no guided onboarding. New users frequently missed how the page worked. With the layout change, the observation controls now sit directly under the photo they apply to, which is a more natural reading order than a narrow right-hand column.

## Notes for reviewer
- `localStorage` access is wrapped in try/catch — Safari private mode and SSR will fail silently rather than throw.
- The Tutorial Context (`useTutorial`) is unchanged; auto-activation uses the same `setRunTutorial((prev) => prev + 1)` pattern the Help button already uses.
- The `ScrollArea` that previously wrapped the observation list was removed since the list no longer has a fixed-height parent. The Paper is now `flexShrink: 0` and grows with content.

## Test plan
- [ ] In a fresh browser profile (or after `localStorage.removeItem("wildmile.hasAnnotated")`), open the camera trap annotation page and confirm the tutorial auto-starts.
- [ ] Save one observation; reload the page and confirm the tutorial does **not** auto-start.
- [ ] Click the **Help** button and confirm the tutorial still launches manually.
- [ ] Verify the ObservationTally renders below the image on desktop (md/lg) and on mobile (base/12).
- [ ] Select 3+ species and verify they wrap horizontally under the image rather than scrolling vertically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)